### PR TITLE
Fix for Server-Side HMR

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -11,7 +11,7 @@ export default class StartServerPlugin {
 
   afterEmit(compilation, callback) {
     if (this.worker && this.worker.isConnected()) {
-      return;
+      return callback();
     }
 
     this.startServer(compilation, callback);


### PR DESCRIPTION
Don't ask my why this matters, but apparently it does for ensuring future updates are watched:

``` diff
diff --git a/lib/start-server-webpack-plugin/index.js b/lib/start-server-webpack-plugin/index.js
index 32a20a3..febc078 100644
--- a/lib/start-server-webpack-plugin/index.js
+++ b/lib/start-server-webpack-plugin/index.js
@@ -11,7 +11,7 @@ export default class StartServerPlugin {

   afterEmit(compilation, callback) {
     if (this.worker && this.worker.isConnected()) {
-      return;
+      return callback();
     }

     this.startServer(compilation, callback);
```
