### PR TITLE
Make sure all files except js are ignored

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -22,7 +22,7 @@ export default class StartServerPlugin {
   }
 
   startServer(compilation, callback) {
-    const entry = Object.keys(compilation.assets).shift();
+    const entry = Object.keys(compilation.assets).filter((asset) => (/.js$/).test(asset)).shift();
     const { existsAt } = compilation.assets[entry];
 
     cluster.setupMaster({ exec: existsAt });


### PR DESCRIPTION
Since `compilation.assets` is an object, there is no guarantee what will be the order of assets. In my case, the first key was a gif. This change makes sure only a js file can be used to run the server.
