### PR TITLE
Allow specifying entry to run

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -1,7 +1,8 @@
 import cluster from "cluster";
 
 export default class StartServerPlugin {
-  constructor() {
+  constructor(entry) {
+    this.entry = entry;
     this.afterEmit = this.afterEmit.bind(this);
     this.apply = this.apply.bind(this);
     this.startServer = this.startServer.bind(this);
@@ -22,7 +23,18 @@ export default class StartServerPlugin {
   }
 
   startServer(compilation, callback) {
-    const entry = Object.keys(compilation.assets).shift();
+    let entry;
+    const entries = Object.keys(compilation.assets);
+    if (this.entry) {
+      entry = this.entry;
+      if (!compilation.assets[entry]) {
+        console.error("Entry " + entry + " not found. Try one of: " + entries.join(" "));
+    } else {
+      entry = entries[0];
+      if (entries.length > 1) {
+        console.log("More than one entry built, selected " + entry + ". All entries: " + entries.join(" "));
+      }
+    }
     const { existsAt } = compilation.assets[entry];
 
     cluster.setupMaster({ exec: existsAt });

--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -29,6 +29,7 @@ export default class StartServerPlugin {
       entry = this.entry;
       if (!compilation.assets[entry]) {
         console.error("Entry " + entry + " not found. Try one of: " + entries.join(" "));
+      }
     } else {
       entry = entries[0];
       if (entries.length > 1) {


### PR DESCRIPTION
When making an entries object, it's not predictable which entry will be first. This patch allows specifying the entry by name.

This is useful when your server consists of eg. several files that run in multiple processes.
