### PR TITLE
Allow setting of inspectPort

### DIFF
--- a/test/StartServerPlugin.test.js
+++ b/test/StartServerPlugin.test.js
@@ -26,4 +26,22 @@ describe("StartServerPlugin", function() {
     expect(args.filter(a => a === 'meep').length).toBe(1);
     expect(args.slice(-2)).toEqual(['--', 'moop']);
   });
+
+  it("should parse the inspect port", function() {
+    const p = new Plugin({nodeArgs: ['--inspect=9230']});
+    const port = p._getInspectPort(p._getArgs())
+    expect(port).toBe(9230)
+  })
+
+  it("should remove host when parsing inspect port", function() {
+    const p = new Plugin({nodeArgs: ['--inspect=localhost:9230']});
+    const port = p._getInspectPort(p._getArgs())
+    expect(port).toBe(9230)
+  })
+
+  it("should return undefined inspect port is not set", function() {
+    const p = new Plugin({nodeArgs: ['--inspect']});
+    const port = p._getInspectPort(p._getArgs())
+    expect(port).toBe(undefined)
+  })
 });


### PR DESCRIPTION
As discussed in #8, changing the default inspect port does not work.
```
new StartServerPlugin({
  name: filename,
  nodeArgs: ['--inspect=127.0.0.1:9231' ] // will still set to default port 😢
}),
```
The issue is that the `cluster` module requires explicitly setting the [inspectPort as a separate option](https://nodejs.org/api/cluster.html#cluster_cluster_settings), aptly named `inspectPort`.

This PR will parse the `--inspect` option passed into `nodeArgs` and pass the port number to `cluster.setupMaster` as a separate option.