### PR TITLE
Send a signal to the server process for HMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ export default {
       name: 'server.js',
       nodeArgs: ['--inspect'], // allow debugging
       args: ['scriptArgument1', 'scriptArgument2'], // pass args to script
+      signal: 'SIGUSR2', // signal to send for HMR (defaults to 'SIGUSR2', set to false to disable)
     }),
     ...
   ],

--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -36,8 +36,26 @@ export default class StartServerPlugin {
     return parseInt(port)
   }
 
+  _getSignal() {
+    const { signal } = this.options;
+    // allow users to disable sending a signal by setting to `false`...
+    if (signal === false) {
+      return;
+    }
+    // allow user to manually set the signal if they'd like
+    if (typeof signal === 'string') {
+      return signal;
+    }
+    // else default to `SIGUSR2` which is what `webpack/hot/signal` uses by default
+    return 'SIGUSR2'
+  }
+
   afterEmit(compilation, callback) {
     if (this.worker && this.worker.isConnected()) {
+      const signal = this._getSignal();
+      if (signal) {
+        process.kill(this.worker.process.pid, signal);
+      }
       return callback();
     }
 

--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -42,12 +42,7 @@ export default class StartServerPlugin {
     if (signal === false) {
       return;
     }
-    // allow user to manually set the signal if they'd like
-    if (typeof signal === 'string') {
-      return signal;
-    }
-    // else default to `SIGUSR2` which is what `webpack/hot/signal` uses by default
-    return 'SIGUSR2'
+    return signal || 'SIGUSR2';
   }
 
   afterEmit(compilation, callback) {

--- a/test/StartServerPlugin.test.js
+++ b/test/StartServerPlugin.test.js
@@ -57,6 +57,12 @@ describe("StartServerPlugin", function() {
     expect(signal).toBe('SIGUSR1');
   })
 
+  it("should allow user to override the default signal", function() {
+    const p = new Plugin({ signal: 2 });
+    const signal = p._getSignal();
+    expect(signal).toBe(2);
+  })
+
   it("should allow user to disable sending a signal", function() {
     const p = new Plugin({ signal: false });
     const signal = p._getSignal();

--- a/test/StartServerPlugin.test.js
+++ b/test/StartServerPlugin.test.js
@@ -44,4 +44,22 @@ describe("StartServerPlugin", function() {
     const port = p._getInspectPort(p._getArgs())
     expect(port).toBe(undefined)
   })
+
+  it("should return default signal if signal is not passed", function() {
+    const p = new Plugin();
+    const signal = p._getSignal();
+    expect(signal).toBe('SIGUSR2');
+  })
+
+  it("should allow user to override the default signal", function() {
+    const p = new Plugin({ signal: 'SIGUSR1' });
+    const signal = p._getSignal();
+    expect(signal).toBe('SIGUSR1');
+  })
+
+  it("should allow user to disable sending a signal", function() {
+    const p = new Plugin({ signal: false });
+    const signal = p._getSignal();
+    expect(signal).toBe(undefined);
+  })
 });


### PR DESCRIPTION
This will send a `SIGUSR2` signal to the server process in the `after-emit` hook.
This allows you to use `webpack/hot/signal` instead of `webpack/hot/poll` so that changes should be instant.

This PR enables the signal by default, but it should not break anything since most apps will just ignore `SIGUSR2`.
If you'd like I can make it opt in only. Let me know if you'd like me to change it.

fixes: #9