### PR TITLE
Add the ability to manually restart the server by typing rs

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -14,6 +14,22 @@ export default class StartServerPlugin {
     this.startServer = this.startServer.bind(this);
 
     this.worker = null;
+    if (this.options.restartable !== false) {
+      this._enableRestarting()
+    }
+  }
+
+  _enableRestarting() {
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', data => {
+      if (data.trim() === 'rs') {
+        console.log('Restarting app...');
+        process.kill(this.worker.process.pid);
+        this._startServer(worker => {
+          this.worker = worker
+        })
+      }
+    });
   }
 
   _getArgs() {
@@ -64,23 +80,30 @@ export default class StartServerPlugin {
       }
     }
     const { existsAt } = compilation.assets[name];
+    this._entryPoint = existsAt;
+
+    this._startServer(worker => {
+      this.worker = worker;
+      callback();
+    })
+  }
+
+  _startServer(callback) {
     const execArgv = this._getArgs();
     const inspectPort = this._getInspectPort(execArgv)
 
     const clusterOptions = {
-      exec: existsAt,
+      exec: this._entryPoint,
       execArgv,
     };
 
     if (inspectPort) {
       clusterOptions.inspectPort = inspectPort
     }
-
     cluster.setupMaster(clusterOptions);
 
     cluster.on("online", (worker) => {
-      this.worker = worker;
-      callback();
+      callback(worker);
     });
 
     cluster.fork();


### PR DESCRIPTION
This is similiar to nodemon.
It's needed if you want to restart the server when making external changes (i.e. changing env variables)

I didn't add any tests because I wasn't sure how to test it :)

What I did is...
1) Extract the actual starting of the server to its own "private" method.
2) add a listener to stdin, kill the current worker and start the server again if the user types `rs`

Currently the implementation allows the user to disable this behavior by passing `restartable: false`.