### PR TITLE
Add support for the new Webpack 4 Hooks API

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -45,7 +45,14 @@ export default class StartServerPlugin {
   }
 
   apply(compiler) {
-    compiler.plugin("after-emit", this.afterEmit);
+    // Use the Webpack 4 Hooks API when possible.
+    if (compiler.hooks) {
+      const plugin = { name: "StartServerPlugin" };
+
+      compiler.hooks.afterEmit.tapAsync(plugin, this.afterEmit)
+    } else {
+      compiler.plugin("after-emit", this.afterEmit);
+    }
   }
 
   startServer(compilation, callback) {


### PR DESCRIPTION
Removes the `Tapable.plugin is deprecated. Use new API on hooks instead` warning when using this plugin with `Webpack >= 4.0.0`.

Plugin is still compatible with lower versions of `Webpack` as it will check if the new hooks are available.

