### PR TITLE
fix passing args to cluster

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -41,14 +41,16 @@ export default class StartServerPlugin {
     }
   }
 
-  _getArgs() {
+  _getExecArgv() {
     const {options} = this;
     const execArgv = (options.nodeArgs || []).concat(process.execArgv);
-    if (options.args) {
-      execArgv.push('--');
-      execArgv.push.apply(execArgv, options.args);
-    }
     return execArgv;
+  }
+
+  _getArgs() {
+    const { options } = this;
+    const argv = (options.args || []);
+    return argv;
   }
 
   _getInspectPort(execArgv) {
@@ -124,12 +126,14 @@ export default class StartServerPlugin {
   }
 
   _startServer(callback) {
-    const execArgv = this._getArgs();
+    const args = this._getArgs();
+    const execArgv = this._getExecArgv();
     const inspectPort = this._getInspectPort(execArgv);
 
     const clusterOptions = {
       exec: this._entryPoint,
       execArgv,
+      args,
     };
 
     if (inspectPort) {

--- a/test/StartServerPlugin.test.js
+++ b/test/StartServerPlugin.test.js
@@ -20,28 +20,35 @@ describe('StartServerPlugin', function() {
     expect(p.options.whee).toBe(true);
   });
 
-  it('should calculate arguments', function() {
+    it('should calculate nodeArgs', function() {
     const p = new Plugin({nodeArgs: ['meep'], args: ['moop']});
+    const nodeArgs = p._getExecArgv();
+    expect(nodeArgs.filter(a => a === 'meep').length).toBe(1);
+  });
+
+  it('should calculate args', function () {
+    const p = new Plugin({ nodeArgs: ['meep'], args: ['moop', 'bleep', 'third'] });
     const args = p._getArgs();
-    expect(args.filter(a => a === 'meep').length).toBe(1);
-    expect(args.slice(-2)).toEqual(['--', 'moop']);
+    expect(args.filter(a => a === 'moop').length).toBe(1);
+    expect(args.filter(a => a === 'bleep').length).toBe(1);
+    expect(args.slice(2)).toEqual(['third']);
   });
 
   it('should parse the inspect port', function() {
     const p = new Plugin({nodeArgs: ['--inspect=9230']});
-    const port = p._getInspectPort(p._getArgs());
+    const port = p._getInspectPort(p._getExecArgv());
     expect(port).toBe(9230);
   });
 
   it('should remove host when parsing inspect port', function() {
     const p = new Plugin({nodeArgs: ['--inspect=localhost:9230']});
-    const port = p._getInspectPort(p._getArgs());
+    const port = p._getInspectPort(p._getExecArgv());
     expect(port).toBe(9230);
   });
 
   it('should return undefined inspect port is not set', function() {
     const p = new Plugin({nodeArgs: ['--inspect']});
-    const port = p._getInspectPort(p._getArgs());
+    const port = p._getInspectPort(p._getExecArgv());
     expect(port).toBe(undefined);
   });
 


### PR DESCRIPTION
Previously passing arguments were failing as node process detecting passed `-- arg=test` as file and trying to open a file named `arg=test`, this PR should fix it

Applied `args` setting as in the documentation here:
https://nodejs.org/api/cluster.html#cluster_cluster_settings