### PR TITLE
fix: use the output path for entry location, 

### DIFF
--- a/src/StartServerPlugin.js
+++ b/src/StartServerPlugin.js
@@ -116,8 +116,8 @@ export default class StartServerPlugin {
         );
       }
     }
-    const {existsAt} = compilation.assets[name];
-    this._entryPoint = existsAt;
+
+    this._entryPoint = path.resolve(compilation.outputOptions.path, name);
 
     this._startServer(worker => {
       this.worker = worker;


### PR DESCRIPTION
Since webpack 5 doesn't have `existsAt` field it is better to relay on "standard" fields :]